### PR TITLE
File types.h was changed for preventing compilation errors.

### DIFF
--- a/include/asm/gbz80/types.h
+++ b/include/asm/gbz80/types.h
@@ -30,7 +30,10 @@ typedef long          	INT32;
  */
 typedef unsigned long 	UINT32;
 
+#ifndef __SIZE_T_DEFINED
+#define __SIZE_T_DEFINED
 typedef int	      	size_t;
+#endif
 
 /** Returned from clock
     @see clock


### PR DESCRIPTION
The commit fixes the problem with duplicate definition of 'size_t' type. The problem occurred when I tried compiling code examples from gbdk-2.96a with sdcc-3.3 and gbdk-n:

$>  sdcc -mgbz80 --no-std-crt0 -I ./gbdk-n-master/bin/../include -I ./gbdk-n-master/bin/../include/asm -c examples/gb/samptest.c
_/usr/local/bin/../share/sdcc/include/stdio.h:46: error 0: Duplicate symbol 'size_t', symbol IGNORED
./gbdk-n-master/bin/../include/asm/gbz80/types.h:33: error 177: previously defined here
/usr/local/bin/../share/sdcc/include/stdio.h:46: error 51: typedef/enum 'size_t' duplicate. Previous definition Ignored_
