### PR TITLE
Fix INT8 that was unsigned instead of signed

### DIFF
--- a/include/asm/gbz80/types.h
+++ b/include/asm/gbz80/types.h
@@ -13,7 +13,7 @@
 
 /** Signed eight bit.
  */
-typedef char          	INT8;
+typedef signed char   	INT8;
 /** Unsigned eight bit.
  */
 typedef unsigned char 	UINT8;


### PR DESCRIPTION
Since 2016, the `char` type is unsigned by default in SDCC. From the SDCC ChageLog:

```
2016-02-01 Philipp Klaus Krause <pkk AT spth.de>

	* src/SDCCglobl.h,
	  src/SDCCmain.c,
	  src/SDCCsymt.c,
	  src/SDCCval.c,
	  doc/sdccman.lyx:
	  Make char unsigned by default.
```
* other source:  https://www.z88dk.org/forum/viewtopic.php?id=9331

As the `INT8` type is based on `char`, this make it unsigned...

This PR fixes the issue. There is also an other possible fix: using the `--fsigned-char` option of the compiler.

Here a small code that reproduce the issue:

```c
#include <stdio.h>
#include <gb/gb.h>

void main(void) {
    INT8 x = 10;
    INT8 dx = -1;
    printf("INT8 x = 10;\n");
    printf("INT8 dx = -1;\n\n");
    printf("x + dx = %i\n", x + dx);
}
```

Result before the fix:

![capture d ecran de 2019-02-25 14-01-19](https://user-images.githubusercontent.com/971438/53339362-7199c280-3906-11e9-8314-c02f98a3b442.png)

And after the patch:

![capture d ecran de 2019-02-25 14-01-34](https://user-images.githubusercontent.com/971438/53339376-7a8a9400-3906-11e9-9880-62dc3ba64ab0.png)

