### PR TITLE
Replaces sdcclib that was removed from SDCC 3.9.0 by sdar

### DIFF
--- a/Make.bat
+++ b/Make.bat
@@ -56,12 +56,10 @@ if exist %LIBDIR%\crt0.rel del %LIBDIR%\crt0.rel
 copy /b/v/y %OBJDIR%\crt0.rel %LIBDIR%\crt0.rel
 
 :: Write list of inputs for the library
-if exist %OBJDIR%\rels.txt del %OBJDIR%\rels.txt
+if exist %LIBDIR%\gb.lib del %LIBDIR%\gb.lib
 for %%A in (%OBJDIR%\*.rel) do (
-	echo %%A >> %OBJDIR%\rels.txt
+	sdar -qv %LIBDIR%\gb.lib %%A
 )
-
-sdcclib -l %LIBDIR%\gb.lib %OBJDIR%\rels.txt	
 
 echo.
 if not exist %LIBDIR%\gb.lib (

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ CA=bin/gbdk-n-assemble.sh
 lib: $(LIBDIR)/gb.lib $(LIBDIR)/crt0.rel
 
 $(LIBDIR)/gb.lib: $(LIBDIR)/crt0.rel
-	ls $(OBJDIR)/*.rel > $(OBJDIR)/rels.txt
-	sdcclib -l $(LIBDIR)/gb.lib $(OBJDIR)/rels.txt	
+	sdar -qv $(LIBDIR)/gb.lib $(OBJDIR)/*.rel
 
 $(LIBDIR)/crt0.rel:
 	chmod u+x bin/*


### PR DESCRIPTION
Hello,

In **SDCC 3.9.0** released in April, the `sdcclib` utility was removed. It is replaced by `sdar`.

This PR allows to build the library on the latest SDCC versions.